### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkAdditiveGaussianNoiseMeshFilter.h
+++ b/include/itkAdditiveGaussianNoiseMeshFilter.h
@@ -43,6 +43,7 @@ public MeshToMeshFilter< TInput, TOutput >
 {
 
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(AdditiveGaussianNoiseMeshFilter);
 
   /** Standard class type alias. */
   using Self = AdditiveGaussianNoiseMeshFilter;
@@ -89,11 +90,6 @@ protected:
   CoordRepType m_Mean;
   CoordRepType m_Sigma;
   int          m_Seed;
-
-private:
-
-  ITK_DISALLOW_COPY_AND_ASSIGN(AdditiveGaussianNoiseMeshFilter);
-
 };
 
 }

--- a/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h
+++ b/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h
@@ -42,6 +42,8 @@ class AdditiveGaussianNoiseQuadEdgeMeshFilter:
   public QuadEdgeMeshToQuadEdgeMeshFilter< TInputMesh, TOutputMesh >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(AdditiveGaussianNoiseQuadEdgeMeshFilter);
+
   /** Standard class type alias. */
   using Self = AdditiveGaussianNoiseQuadEdgeMeshFilter;
   using Superclass = QuadEdgeMeshToQuadEdgeMeshFilter< TInputMesh, TOutputMesh >;
@@ -82,11 +84,6 @@ protected:
   CoordRepType m_Mean;
   CoordRepType m_Sigma;
   int          m_Seed;
-
-private:
-
-  ITK_DISALLOW_COPY_AND_ASSIGN(AdditiveGaussianNoiseQuadEdgeMeshFilter);
-
 };
 
 } // end namespace itk


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.