### PR TITLE
ENH: Add CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+version: 2
+jobs:
+  build-and-test:
+    working_directory: /DVMeshNoise-build
+    docker:
+      - image: insighttoolkit/module-ci:latest
+    steps:
+      - checkout:
+          path: /DVMeshNoise
+      - run:
+          name: Fetch CTest driver script
+          command: |
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+      - run:
+          name: Configure CTest script
+          command: |
+            SHASNIP=$(echo $CIRCLE_SHA1 | cut -c1-7)
+            cat > dashboard.cmake << EOF
+            set(CTEST_SITE "CircleCI")
+            set(CTEST_BUILD_NAME "External-DVMeshNoise-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
+            set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+            set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+            set(CTEST_BUILD_FLAGS: "-j5")
+            set(CTEST_SOURCE_DIRECTORY /DVMeshNoise)
+            set(CTEST_BINARY_DIRECTORY /DVMeshNoise-build)
+            set(dashboard_model Experimental)
+            set(dashboard_no_clean 1)
+            set(dashboard_cache "
+            ITK_DIR:PATH=/ITK-build
+            BUILD_TESTING:BOOL=ON
+            ")
+            include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+            EOF
+      - run:
+          name: Build and Test
+          no_output_timeout: 1.0h
+          command: |
+            ctest -j 2 -VV -S dashboard.cmake
+  package:
+    working_directory: ~/DVMeshNoise
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Fetch build script
+          command: |
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
+            chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
+      - run:
+          name: Build Python packages
+          no_output_timeout: 1.0h
+          command: |
+            ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
+      - store_artifacts:
+          path: dist
+          destination: dist
+
+workflows:
+    version: 2
+    build-test-package:
+      jobs:
+        - build-and-test
+        - package

--- a/CTestConfig,cmake
+++ b/CTestConfig,cmake
@@ -1,0 +1,8 @@
+set(CTEST_PROJECT_NAME "ITK")
+set(CTEST_NIGHTLY_START_TIME "1:00:00 UTC")
+
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "open.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=Insight")
+set(CTEST_DROP_SITE_CDASH TRUE)
+

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,32 @@
 DVMeshNoise
 ===========
 
+.. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/DVMeshNoise.svg?style=shield
+    :target: https://circleci.com/gh/InsightSoftwareConsortium/DVMeshNoise
+.. |TravisCI| image:: https://travis-ci.org/InsightSoftwareConsortium/DVMeshNoise.svg?branch=master
+    :target: https://travis-ci.org/InsightSoftwareConsortium/DVMeshNoise
+.. |AppVeyor| image:: https://img.shields.io/appveyor/ci/itkrobot/dvmeshnoise.svg
+    :target: https://ci.appveyor.com/project/itkrobot/dvmeshnoise
+
+=========== =========== ===========
+   Linux      macOS       Windows
+=========== =========== ===========
+|CircleCI|  |TravisCI|  |AppVeyor|
+=========== =========== ===========
+
+
 Overview
 --------
 
-`DVMeshNoise` is an ITK module which allows Gaussian noise to be added
-to the coordinates of an `itk::Mesh` or `itk::QuadEdgeMesh`.
+This module contains classes to perturb `itk::Mesh` and `itk::QuadEdgeMesh`
+objects with Gaussian noise.
 
-A technical report for the Insight Journal introducing this module is
-maintained at https://github.com/DVigneault/DVMeshNoiseSubmission.
+For more information, see the `Insight Journal article <http://hdl.handle.net/10380/3567>`_::
+  Vigneault D.
+  Perturbing Mesh Vertices with Additive Gaussian Noise
+  The Insight Journal. January-December. 2016.
+  http://hdl.handle.net/10380/3567
+  http://www.insight-journal.org/browse/publication/981
 
 
 License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+branches:
+ only:
+  - master
+
+version: "0.0.1.{build}"
+
+install:
+
+  - curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/windows-download-cache-and-build-module-wheels.ps1 -O
+  - ps: .\windows-download-cache-and-build-module-wheels.ps1
+
+build: off
+
+test: off
+
+artifacts:
+
+  # pushing entire folder as a zip archive
+  - path: dist\*
+
+deploy: off

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,8 +1,15 @@
-set(DOCUMENTATION "This module contains classes to perturb
-itk::Mesh and itk::QuadEdgeMesh objects with Gaussian noise.
-This module is introduced in the Insight Journal article
-http://hdl.handle.net/10380/3567")
 
+# the top-level README is used for describing this module, just
+# re-used it for documentation here
+get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
+
+# itk_module() defines the module dependencies in DVMeshNoise
+# The testing module in DVMeshNoise depends on ITKTestKernel
+# By convention those modules outside of ITK are not prefixed with
+# ITK.
+
+# define the dependencies of the include module and the tests
 itk_module(DVMeshNoise
   DEPENDS
     ITKCommon

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from os import sys
+
+try:
+    from skbuild import setup
+except ImportError:
+    print('scikit-build is required to build from source.', file=sys.stderr)
+    print('Please run:', file=sys.stderr)
+    print('', file=sys.stderr)
+    print('  python -m pip install scikit-build')
+    sys.exit(1)
+
+setup(
+    name='dvmeshnoise',
+    version='0.0.1',
+    author='Davis Vigneault',
+    author_email='davis.vigneault@gmail.com',
+    packages=['itk'],
+    package_dir={'itk': 'itk'},
+    download_url=r'https://github.com/InsightSoftwareConsortium/DVMeshNoise',
+    description=r'Classes to perturb mesh objects with Gaussian noise',
+    long_description='DVMeshNoise provides classes to perturb mesh objects'
+                     'with Gaussian noise.\n'
+                     'Please refer to:'
+                     'Vigneault D.,'
+                     '“Perturbing Mesh Vertices with Additive Gaussian Noise”, '
+                     'Insight Journal, http://hdl.handle.net/10380/3567, 2016.',
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: C++",
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Healthcare Industry",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Medical Science Apps.",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Software Development :: Libraries",
+        "Operating System :: Android",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Operating System :: Unix",
+        "Operating System :: MacOS"
+        ],
+    license='Apache',
+    keywords='ITK InsightToolkit',
+    url=r'https://itk.org/',
+    install_requires=[
+        r'itk'
+    ]
+    )

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,15 @@
+sudo: true
+language: cpp
+os:
+- osx
+compiler:
+- gcc
+cache:
+  directories:
+  - "$HOME/Library/Caches/Homebrew"
+script:
+- curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
+- chmod u+x macpython-download-cache-and-build-module-wheels.sh
+- ./macpython-download-cache-and-build-module-wheels.sh
+- tar -zcvf dist.tar.gz dist/
+- curl --upload-file dist.tar.gz https://transfer.sh/dist.tar.gz

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,0 +1,8 @@
+itk_wrap_module(DVMeshNoise)
+
+set(WRAPPER_SUBMODULE_ORDER
+   AdditiveGaussianNoiseMeshFilter
+   AdditiveGaussianNoiseQuadEdgeMeshFilter)
+
+itk_auto_load_submodules()
+itk_end_wrap_module()

--- a/wrapping/itkAdditiveGaussianNoiseMeshFilter.wrap
+++ b/wrapping/itkAdditiveGaussianNoiseMeshFilter.wrap
@@ -1,0 +1,12 @@
+itk_wrap_include("itkMeshToMeshFilter.h")
+
+itk_wrap_class("itk::AdditiveGaussianNoiseMeshFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("M${ITKM_${t}}${d}ST${ITKM_${t}}${d}${d}${ITKM_${t}}M${ITKM_${t}}${d}ST${ITKM_${t}}${d}${d}${ITKM_${t}}${ITKM_${t}}"
+        "itk::Mesh< ${ITKT_${t}},${d},itk::DefaultStaticMeshTraits< ${ITKT_${t}},${d},${d},${ITKT_${t}} > >, itk::Mesh< ${ITKT_${t}},${d},itk::DefaultStaticMeshTraits< ${ITKT_${t}},${d},${d},${ITKT_${t}},${ITKT_${t}} > >")
+      itk_wrap_template("M${ITKM_${t}}${d}DT${ITKM_${t}}${d}${d}${ITKM_${t}}M${ITKM_${t}}${d}DT${ITKM_${t}}${d}${d}${ITKM_${t}}${ITKM_${t}}"
+        "itk::Mesh< ${ITKT_${t}},${d},itk::DefaultDynamicMeshTraits< ${ITKT_${t}},${d},${d},${ITKT_${t}} > >, itk::Mesh< ${ITKT_${t}},${d},itk::DefaultDynamicMeshTraits< ${ITKT_${t}},${d},${d},${ITKT_${t}},${ITKT_${t}} > >")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/wrapping/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.wrap
+++ b/wrapping/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.wrap
@@ -1,0 +1,7 @@
+itk_wrap_include("itkQuadEdgeMesh.h")
+
+itk_wrap_class("itk::AdditiveGaussianNoiseQuadEdgeMeshFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    itk_wrap_template("QEM${ITKM_D}${d}QEM${ITKM_D}${d}" "itk::QuadEdgeMesh< ${ITKT_D},${d} >, itk::QuadEdgeMesh< ${ITKT_D},${d} >")
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
- Add `*.yml` configuration files for CI.
- Update the `README.rst` file to reflect the CI status.
- Modify the current `CTestConfig.cmake` file to make the build
  results be sent to the **Insight** project in **open.cdash.org**.
- Add the necessary `*.wrap` files.
- Add the `setup.py` file for Python packaging.
- Modify the `itk-module.cmake` to take advantage of the module
  documentation in the `README.rst` file.
- Take advantage to improve the `README` file contents.