### PR TITLE
DOC: Fix the IJ ref format in `README.rst`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ This module contains classes to perturb `itk::Mesh` and `itk::QuadEdgeMesh`
 objects with Gaussian noise.
 
 For more information, see the `Insight Journal article <http://hdl.handle.net/10380/3567>`_::
+
   Vigneault D.
   Perturbing Mesh Vertices with Additive Gaussian Noise
   The Insight Journal. January-December. 2016.


### PR DESCRIPTION
Fix the IJ article reference format in the `README.rst` file: add a
newline after the double colon so that the ref is formatted to a literal
block.