### PR TITLE
DOC: Fix syntax errors in `README.rst`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,11 @@ DVMeshNoise
 Overview
 --------
 
-This module contains classes to perturb `itk::Mesh` and `itk::QuadEdgeMesh`
+This module contains classes to perturb ``itk::Mesh`` and ``itk::QuadEdgeMesh``
 objects with Gaussian noise.
 
 For more information, see the `Insight Journal article <http://hdl.handle.net/10380/3567>`_::
+
   Vigneault D.
   Perturbing Mesh Vertices with Additive Gaussian Noise
   The Insight Journal. January-December. 2016.


### PR DESCRIPTION
Fix formatting errors in `README.rst`.
- Fix the ITK classes syntax so that they are inline literals: add the
  missing back quoutes.
- Fix the IJ article reference syntax: add a newline after the
double colon so that the ref is formatted to a literal block.