### PR TITLE
DOC: Follow repository naming convention.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2
 jobs:
   build-and-test:
-    working_directory: /DVMeshNoise-build
+    working_directory: /ITKMeshNoise-build
     docker:
       - image: insighttoolkit/module-ci:latest
     steps:
       - checkout:
-          path: /DVMeshNoise
+          path: /ITKMeshNoise
       - run:
           name: Fetch CTest driver script
           command: |
@@ -17,12 +17,12 @@ jobs:
             SHASNIP=$(echo $CIRCLE_SHA1 | cut -c1-7)
             cat > dashboard.cmake << EOF
             set(CTEST_SITE "CircleCI")
-            set(CTEST_BUILD_NAME "External-DVMeshNoise-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
+            set(CTEST_BUILD_NAME "External-ITKMeshNoise-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
             set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
             set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
             set(CTEST_BUILD_FLAGS: "-j5")
-            set(CTEST_SOURCE_DIRECTORY /DVMeshNoise)
-            set(CTEST_BINARY_DIRECTORY /DVMeshNoise-build)
+            set(CTEST_SOURCE_DIRECTORY /ITKMeshNoise)
+            set(CTEST_BINARY_DIRECTORY /ITKMeshNoise-build)
             set(dashboard_model Experimental)
             set(dashboard_no_clean 1)
             set(dashboard_cache "
@@ -37,7 +37,7 @@ jobs:
           command: |
             ctest -j 2 -VV -S dashboard.cmake
   package:
-    working_directory: ~/DVMeshNoise
+    working_directory: ~/ITKMeshNoise
     machine: true
     steps:
       - checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10.2)
 
-project(DVMeshNoise)
+project(MeshNoise)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
-DVMeshNoise
-===========
+ITKMeshNoise
+============
 
-.. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/DVMeshNoise.svg?style=shield
-    :target: https://circleci.com/gh/InsightSoftwareConsortium/DVMeshNoise
-.. |TravisCI| image:: https://travis-ci.org/InsightSoftwareConsortium/DVMeshNoise.svg?branch=master
-    :target: https://travis-ci.org/InsightSoftwareConsortium/DVMeshNoise
-.. |AppVeyor| image:: https://img.shields.io/appveyor/ci/itkrobot/dvmeshnoise.svg
-    :target: https://ci.appveyor.com/project/itkrobot/dvmeshnoise
+.. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/ITKMeshNoise.svg?style=shield
+    :target: https://circleci.com/gh/InsightSoftwareConsortium/ITKMeshNoise
+.. |TravisCI| image:: https://travis-ci.org/InsightSoftwareConsortium/ITKMeshNoise.svg?branch=master
+    :target: https://travis-ci.org/InsightSoftwareConsortium/ITKMeshNoise
+.. |AppVeyor| image:: https://img.shields.io/appveyor/ci/itkrobot/itkmeshnoise.svg
+    :target: https://ci.appveyor.com/project/itkrobot/itkmeshnoise
 
 =========== =========== ===========
    Linux      macOS       Windows

--- a/include/itkAdditiveGaussianNoiseMeshFilter.h
+++ b/include/itkAdditiveGaussianNoiseMeshFilter.h
@@ -35,7 +35,7 @@ namespace itk
  * counteracting deleterious effects which highly regular regions
  * of a mesh may occassionally have on mesh processing.
  *
- * \ingroup DVMeshNoise
+ * \ingroup MeshNoise
  */
 template< typename TInput, typename TOutput = TInput >
 class AdditiveGaussianNoiseMeshFilter:

--- a/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h
+++ b/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h
@@ -35,7 +35,7 @@ namespace itk
  * counteracting deleterious effects which highly regular regions
  * of a mesh may occassionally have on mesh processing.
  *
- * \ingroup DVMeshNoise
+ * \ingroup MeshNoise
  */
 template< typename TInputMesh, typename TOutputMesh = TInputMesh >
 class AdditiveGaussianNoiseQuadEdgeMeshFilter:

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -4,13 +4,13 @@
 get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 
-# itk_module() defines the module dependencies in DVMeshNoise
-# The testing module in DVMeshNoise depends on ITKTestKernel
+# itk_module() defines the module dependencies in MeshNoise
+# The testing module in MeshNoise depends on ITKTestKernel
 # By convention those modules outside of ITK are not prefixed with
 # ITK.
 
 # define the dependencies of the include module and the tests
-itk_module(DVMeshNoise
+itk_module(MeshNoise
   DEPENDS
     ITKCommon
     ITKMesh

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,15 @@ except ImportError:
     sys.exit(1)
 
 setup(
-    name='dvmeshnoise',
+    name='itk-meshnoise',
     version='0.0.1',
     author='Davis Vigneault',
     author_email='davis.vigneault@gmail.com',
     packages=['itk'],
     package_dir={'itk': 'itk'},
-    download_url=r'https://github.com/InsightSoftwareConsortium/DVMeshNoise',
+    download_url=r'https://github.com/InsightSoftwareConsortium/ITKMeshNoise',
     description=r'Classes to perturb mesh objects with Gaussian noise',
-    long_description='DVMeshNoise provides classes to perturb mesh objects'
+    long_description='ITKMeshNoise provides classes to perturb mesh objects'
                      'with Gaussian noise.\n'
                      'Please refer to:'
                      'Vigneault D.,'
@@ -46,8 +46,8 @@ setup(
         "Operating System :: MacOS"
         ],
     license='Apache',
-    keywords='ITK InsightToolkit',
-    url=r'https://itk.org/',
+    keywords='ITK InsightToolkit mesh noise',
+    url=r'https://github.com/InsightSoftwareConsortium/ITKMeshNoise',
     install_requires=[
         r'itk'
     ]

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,4 +1,4 @@
-itk_wrap_module(DVMeshNoise)
+itk_wrap_module(MeshNoise)
 
 set(WRAPPER_SUBMODULE_ORDER
    AdditiveGaussianNoiseMeshFilter


### PR DESCRIPTION
Follow remote module repository naming convention: add the `ITK` prefix to
the **project name**, and keep the prefix out of the **module name**.

Specifically:
- Fix the **module name** in the main `CMakeLists.txt` file.
- Fix the **module name** in the wrapping `CMakeLists.txt` file.
- Fix the **module name** in the `itk-module.cmake` file.
- Fix the **project name** in the `setup` section of the `setup.py` file.
- Change the **project name** in the `config.yml` Circle CI `yml` file.
- Fix the **module name** for the `\ingroup` Doxygen documentation
  keyword.
- Take advantage of the change to set the URL to the repository site in
  `setup.py`.
- Take advantage of the change to add keywords describing the module to
  `setup.py`.