### PR TITLE
BUG: Fix wrapping modules names.

### DIFF
--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,8 +1,8 @@
 itk_wrap_module(DVMeshNoise)
 
 set(WRAPPER_SUBMODULE_ORDER
-   AdditiveGaussianNoiseMeshFilter
-   AdditiveGaussianNoiseQuadEdgeMeshFilter)
+   itkAdditiveGaussianNoiseMeshFilter
+   itkAdditiveGaussianNoiseQuadEdgeMeshFilter)
 
 itk_auto_load_submodules()
 itk_end_wrap_module()


### PR DESCRIPTION
Fix wrapping modules names: add the missing `itk` prefix.