### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkAdditiveGaussianNoiseMeshFilter.hxx
+++ b/include/itkAdditiveGaussianNoiseMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkAdditiveGaussianNoiseMeshFilter_hxx
 #define itkAdditiveGaussianNoiseMeshFilter_hxx
 
-#include "itkAdditiveGaussianNoiseMeshFilter.h"
 #include "itkNormalVariateGenerator.h"
 
 namespace itk

--- a/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.hxx
+++ b/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkAdditiveGaussianNoiseQuadEdgeMeshFilter_hxx
 #define itkAdditiveGaussianNoiseQuadEdgeMeshFilter_hxx
 
-#include "itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h"
 #include "itkNormalVariateGenerator.h"
 
 namespace itk


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

