### PR TITLE
ENH: Use itk::MakeFilled to avoid deprecated usage

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "c679de253e80e2512fa0c072911414c9068f33e3"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "c679de253e80e2512fa0c072911414c9068f33e3"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "c679de253e80e2512fa0c072911414c9068f33e3"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -133,7 +133,7 @@ jobs:
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.2.1.post1"
 
     steps:
     - uses: actions/checkout@v2
@@ -169,7 +169,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.2.1.post1"
 
     steps:
     - uses: actions/checkout@v2
@@ -198,7 +198,7 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.2.1.post1"
 
     steps:
     - uses: actions/checkout@v2

--- a/test/itkAdditiveGaussianNoiseMeshFilterTest.cxx
+++ b/test/itkAdditiveGaussianNoiseMeshFilterTest.cxx
@@ -15,9 +15,10 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <itkMesh.h>
-#include <itkRegularSphereMeshSource.h>
-#include <itkAdditiveGaussianNoiseMeshFilter.h>
+#include "itkAdditiveGaussianNoiseMeshFilter.h"
+#include "itkMakeFilled.h"
+#include "itkMesh.h"
+#include "itkRegularSphereMeshSource.h"
 #include "itkTestingMacros.h"
 
 int
@@ -34,6 +35,7 @@ itkAdditiveGaussianNoiseMeshFilterTest(int itkNotUsed(argc), char * itkNotUsed(a
   using TMesh = itk::Mesh<TPixel, Dimension>;
   using TSphere = itk::RegularSphereMeshSource<TMesh>;
   using TNoise = itk::AdditiveGaussianNoiseMeshFilter<TMesh>;
+  using VectorType = typename TSphere::VectorType;
 
   ////////////////
   // Parameters //
@@ -53,7 +55,7 @@ itkAdditiveGaussianNoiseMeshFilterTest(int itkNotUsed(argc), char * itkNotUsed(a
   TSphere::Pointer sphere = TSphere::New();
 
   sphere->SetResolution(SPHERE_RESOLUTION);
-  sphere->SetScale(SPHERE_SCALE);
+  sphere->SetScale(itk::MakeFilled<VectorType>(SPHERE_SCALE));
 
   TNoise::Pointer noise = TNoise::New();
 

--- a/test/itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest.cxx
+++ b/test/itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest.cxx
@@ -15,9 +15,10 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <itkQuadEdgeMesh.h>
-#include <itkRegularSphereMeshSource.h>
-#include <itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h>
+#include "itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h"
+#include "itkMakeFilled.h"
+#include "itkQuadEdgeMesh.h"
+#include "itkRegularSphereMeshSource.h"
 #include "itkTestingMacros.h"
 
 int
@@ -34,6 +35,7 @@ itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest(int itkNotUsed(argc), char * itkN
   using TMesh = itk::QuadEdgeMesh<TPixel, Dimension>;
   using TSphere = itk::RegularSphereMeshSource<TMesh>;
   using TNoise = itk::AdditiveGaussianNoiseQuadEdgeMeshFilter<TMesh>;
+  using VectorType = typename TSphere::VectorType;
 
   ////////////////
   // Parameters //
@@ -53,7 +55,7 @@ itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest(int itkNotUsed(argc), char * itkN
   TSphere::Pointer sphere = TSphere::New();
 
   sphere->SetResolution(SPHERE_RESOLUTION);
-  sphere->SetScale(SPHERE_SCALE);
+  sphere->SetScale(itk::MakeFilled<VectorType>(SPHERE_SCALE));
 
   TNoise::Pointer noise = TNoise::New();
 


### PR DESCRIPTION
The implicit conversion of a scalar to a vector filled with that value is now deprecated.  Instead we use the explicit `itk::MakeFilled` function.