### PR TITLE
ENH: Bump ITK and replace http with https using script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@
 ## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
 ##
 ## The clang-format binaries can be downloaded as part of the clang binary distributions
-## from http://releases.llvm.org/download.html
+## from https://releases.llvm.org/download.html
 ##
 ## Use the script Utilities/Maintenance/clang-format.bash to faciliate
 ## maintaining a consistent code style.

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -131,9 +131,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [36, 37, 38, 39]
+        python-version: [37, 38, 39, 310]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
     - uses: actions/checkout@v2
@@ -169,7 +169,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
     - uses: actions/checkout@v2
@@ -196,9 +196,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [6, 7, 8, 9]
+        python-version-minor: [7, 8, 9, 10]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
     - uses: actions/checkout@v2
@@ -228,7 +228,7 @@ jobs:
       run: |
         cd ../../im
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        set PATH="C:\P\grep;%PATH%"
+        set PATH=C:\P\grep;%PATH%
         set CC=cl.exe
         set CXX=cl.exe
         C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64" --no-cleanup

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,10 @@ Overview
 This module contains classes to perturb ``itk::Mesh`` and ``itk::QuadEdgeMesh``
 objects with Gaussian noise.
 
-For more information, see the `Insight Journal article <http://hdl.handle.net/10380/3567>`_::
+For more information, see the `Insight Journal article <https://hdl.handle.net/10380/3567>`_::
 
   Vigneault D.
   Perturbing Mesh Vertices with Additive Gaussian Noise
   The Insight Journal. January-December. 2016.
-  http://hdl.handle.net/10380/3567
-  http://www.insight-journal.org/browse/publication/981
+  https://hdl.handle.net/10380/3567
+  https://www.insight-journal.org/browse/publication/981

--- a/include/itkAdditiveGaussianNoiseMeshFilter.h
+++ b/include/itkAdditiveGaussianNoiseMeshFilter.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkAdditiveGaussianNoiseMeshFilter.hxx
+++ b/include/itkAdditiveGaussianNoiseMeshFilter.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h
+++ b/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.hxx
+++ b/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
                      'Please refer to:\n'
                      'Vigneault D., '
                      '"Perturbing Mesh Vertices with Additive Gaussian Noise", '
-                     'Insight Journal, January-December 2016, http://hdl.handle.net/10380/3567.',
+                     'Insight Journal, January-December 2016, https://hdl.handle.net/10380/3567.',
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",

--- a/test/itkAdditiveGaussianNoiseMeshFilterTest.cxx
+++ b/test/itkAdditiveGaussianNoiseMeshFilterTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest.cxx
+++ b/test/itkAdditiveGaussianNoiseQuadEdgeMeshFilterTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Automated reformatting with https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/Maintenance/ApplyScriptToRemotes.sh