### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkAdditiveGaussianNoiseMeshFilter.h
+++ b/include/itkAdditiveGaussianNoiseMeshFilter.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AdditiveGaussianNoiseMeshFilter, MeshToMeshFilter);
+  itkOverrideGetNameOfClassMacro(AdditiveGaussianNoiseMeshFilter);
 
   /** Mean of noise. */
   itkGetConstMacro(Mean, CoordRepType);

--- a/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h
+++ b/include/itkAdditiveGaussianNoiseQuadEdgeMeshFilter.h
@@ -56,7 +56,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AdditiveGaussianNoiseQuadEdgeMeshFilter, QuadEdgeMeshToQuadEdgeMeshFilter);
+  itkOverrideGetNameOfClassMacro(AdditiveGaussianNoiseQuadEdgeMeshFilter);
 
   /** Mean of noise. */
   itkGetConstMacro(Mean, CoordRepType);


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
