### PR TITLE
ENH: Add EXCLUDE_FROM_DEFAULT to MeshNoise module

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -18,6 +18,8 @@ itk_module(MeshNoise
     ITKStatistics
   TEST_DEPENDS
     ITKTestKernel
+  EXCLUDE_FROM_DEFAULT
   DESCRIPTION
     "${DOCUMENTATION}"
 )
+ 


### PR DESCRIPTION
This change excludes the MeshNoise module from the default ITK build, making it an optional module that must be explicitly enabled.

## Motivation

The MeshNoise module should be opt-in rather than included by default in ITK builds, following the pattern of other specialized remote modules.

## Changes

- Added `EXCLUDE_FROM_DEFAULT` option to the `itk_module()` declaration in `itk-module.cmake`

This ensures the module will only be built when explicitly enabled via:
```cmake
-DModule_MeshNoise=ON
```

cc @blowekamp